### PR TITLE
don't need pc0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Note: Starting with OpenBSD 6.0, this is done by the installer.
 The following settings are required for proper serial console output:
 
 ```
-stty pc0 115200
 stty com0 115200
 set tty com0
 ```


### PR DESCRIPTION
The APU2 doesn't provide a pc0 console ("vga") and it ends in this
reboot cycle when not switching to serial.

http://marc.info/?l=openbsd-misc&m=148409132120896&w=2